### PR TITLE
Fix unquoted template strings and CSS link

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <title>Canadian Trail</title>
 
   <!-- IMPORTANT: relative paths for GitHub Pages repo subpaths -->
-  <link rel="preload" href="./styles.css" as="style">
-  <link rel="stylesheet" href="./styles.css">
+  <link rel="preload" href="./style.css" as="style">
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body>
   <!-- Accessible skip link (hidden by CSS until focused) -->

--- a/systems/status.js
+++ b/systems/status.js
@@ -85,11 +85,11 @@ after.push({ type: 'recovered', cond });
 }
 }
 if (after.length) {
-// Remove expired and write logs
-for (const a of after) {
-const { cond } = a;
-game.data.log.push(${cond.emoji} Recovered from ${cond.name}.);
-}
+    // Remove expired and write logs
+    for (const a of after) {
+    const { cond } = a;
+    game.data.log.push(`${cond.emoji} Recovered from ${cond.name}.`);
+    }
 game.data.status.conditions = game.data.status.conditions.filter(c => c.daysRemaining > 0);
 }
 
@@ -121,8 +121,8 @@ hungerMult: typeof pick?.effects?.hungerMult === 'number' ? pick.effects.hungerM
 },
 blurb: pick.blurb || ''
 };
-game.data.status.conditions.push(instance);
-game.data.log.push(${instance.emoji} ${instance.name} — ${instance.blurb} (${dur} day${dur > 1 ? 's' : ''}).);
+      game.data.status.conditions.push(instance);
+      game.data.log.push(`${instance.emoji} ${instance.name} — ${instance.blurb} (${dur} day${dur > 1 ? 's' : ''}).`);
 }
 }
 }
@@ -178,17 +178,17 @@ const party = game.data.party || [];
 for (const m of party) {
 if (m.status !== 'dead') {
 m.health = Math.max(0, Math.min(5, (m.health | 0) + delta));
-if (m.health === 0) {
-m.status = 'dead';
-game.data.log.push(${m.name} died${reason ? (${reason}) : ''}.);
+      if (m.health === 0) {
+      m.status = 'dead';
+      game.data.log.push(`${m.name} died${reason ? ` (${reason})` : ''}.`);
+      }
 }
 }
-}
-if (delta > 0) {
-game.data.log.push(Party recovered ${delta} health each${reason ? (${reason}) : ''}.);
-} else {
-game.data.log.push(Party lost ${-delta} health each${reason ? (${reason}) : ''}.);
-}
+  if (delta > 0) {
+  game.data.log.push(`Party recovered ${delta} health each${reason ? ` (${reason})` : ''}.`);
+  } else {
+  game.data.log.push(`Party lost ${-delta} health each${reason ? ` (${reason})` : ''}.`);
+  }
 }
 
 /** Small utility for UI to list active funny chips (optional for now) */

--- a/systems/travel.js
+++ b/systems/travel.js
@@ -131,7 +131,7 @@ const paceLabel = {
 [PACE.STRENUOUS]: 'Strenuous',
 [PACE.GRUELING]: 'Grueling'
 }[pace] || 'Steady';
-const summary = ${paceLabel} pace: traveled ${milesTraveled} mi, ate ${foodConsumed} lb${starvation ? ' (shortage!)' : ''}${healthDelta ? , health ${healthDelta > 0 ? '+' : ''}${healthDelta} : ''}.;
+const summary = `${paceLabel} pace: traveled ${milesTraveled} mi, ate ${foodConsumed} lb${starvation ? ' (shortage!)' : ''}${healthDelta ? `, health ${healthDelta > 0 ? '+' : ''}${healthDelta}` : ''}.`;
 game.data.log.push(summary);
 
 return { milesTraveled, foodConsumed, healthDelta, starvation };
@@ -175,7 +175,7 @@ healthDelta += (w.healthDelta | 0) + (s.healthDelta | 0);
 if (healthDelta !== 0) applyHealthToParty(game, healthDelta);
 game.data.day = (game.data.day | 0) + 1;
 
-const summary = Rested: ate ${foodConsumed} lb${shortage ? ' (shortage!)' : ''}${healthDelta ? , health ${healthDelta > 0 ? '+' : ''}${healthDelta} : ''}.;
+const summary = `Rested: ate ${foodConsumed} lb${shortage ? ' (shortage!)' : ''}${healthDelta ? `, health ${healthDelta > 0 ? '+' : ''}${healthDelta}` : ''}.`;
 game.data.log.push(summary);
 
 return { milesTraveled: 0, foodConsumed, healthDelta, starvation: shortage > 0 };

--- a/systems/weather.js
+++ b/systems/weather.js
@@ -84,7 +84,7 @@ blurb: p.blurb,
 mods: { ...p.mods }
 };
 // friendly log line
-game.data.log.push(Weather — ${p.emoji} ${p.name}: ${p.blurb});
+game.data.log.push(`Weather — ${p.emoji} ${p.name}: ${p.blurb}`);
 return gw.today;
 }
 
@@ -108,9 +108,9 @@ export function describeToday(game) {
 const t = getToday(game);
 if (!t) return 'Weather — (unknown)';
 const m = t.mods || {};
-const spd = m.speedMult && m.speedMult !== 1 ? speed×${m.speedMult.toFixed(2)} : '';
-const hp = m.healthDelta ? health ${m.healthDelta > 0 ? '+' : ''}${m.healthDelta} : '';
-const eat = m.hungerMult && m.hungerMult !== 1 ? appetite×${m.hungerMult.toFixed(2)} : '';
+const spd = m.speedMult && m.speedMult !== 1 ? `speed×${m.speedMult.toFixed(2)}` : '';
+const hp = m.healthDelta ? `health ${m.healthDelta > 0 ? '+' : ''}${m.healthDelta}` : '';
+const eat = m.hungerMult && m.hungerMult !== 1 ? `appetite×${m.hungerMult.toFixed(2)}` : '';
 const parts = [spd, hp, eat].filter(Boolean).join(', ');
-return Weather — ${t.emoji} ${t.name}${parts ? (${parts}) : ''};
+return `Weather — ${t.emoji} ${t.name}${parts ? ` (${parts})` : ''}`;
 }


### PR DESCRIPTION
## Summary
- wrap stray `${...}` strings in template literals across travel, weather, and status systems
- point index.html stylesheet link to existing `style.css`

## Testing
- `npm test` *(fails: Invalid package.json)*
- `node tests/run.js` *(fails: Error parsing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ec384db88320ac1a92e27913d62a