### PR TITLE
Handle legacy save data for travel screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-```json
 {
   "name": "canadian-trail",
   "version": "0.1.0",

--- a/state/GameState.js
+++ b/state/GameState.js
@@ -99,7 +99,29 @@ export class GameState {
     parsed.money ??= 50;
     parsed.morale ??= 0;
     parsed.buffs ??= {};
+    parsed.flags ??= {};
+    if (typeof parsed.flags !== 'object' || parsed.flags === null) parsed.flags = {};
+    parsed.settings ??= { pace: 'steady', rations: 'normal' };
+    if (typeof parsed.settings !== 'object' || parsed.settings === null) {
+      parsed.settings = { pace: 'steady', rations: 'normal' };
+    } else {
+      parsed.settings.pace ??= 'steady';
+      parsed.settings.rations ??= 'normal';
+    }
+    if (!parsed.inventory || typeof parsed.inventory !== 'object') {
+      parsed.inventory = { food: 0, bullets: 0, clothes: 0, wheel: 0, axle: 0, tongue: 0, medicine: 0 };
+    } else {
+      parsed.inventory.food ??= 0;
+      parsed.inventory.bullets ??= 0;
+      parsed.inventory.clothes ??= 0;
+      parsed.inventory.wheel ??= 0;
+      parsed.inventory.axle ??= 0;
+      parsed.inventory.tongue ??= 0;
+      parsed.inventory.medicine ??= 0;
+    }
+    if (!Array.isArray(parsed.party)) parsed.party = [];
     parsed.epitaphs ??= defaultEpitaphs();
+    if (!Array.isArray(parsed.log)) parsed.log = [];
     this.data = parsed;
     this.rng = new RNG(this.data.rngState || this.data.rngSeed || 1);
   }


### PR DESCRIPTION
## Summary
- ensure `GameState.continueGame()` backfills missing fields from legacy saves so the travel screen initializes instead of failing
- fix `package.json` formatting so Node/NPM commands can run normally

## Testing
- node tests/run.js

------
https://chatgpt.com/codex/tasks/task_e_68c86852ac9483209b1814d763d7646d